### PR TITLE
fix(ios): remove instance of camera view

### DIFF
--- a/src/ios/CordovaBambuserBroadcaster.m
+++ b/src/ios/CordovaBambuserBroadcaster.m
@@ -51,6 +51,7 @@
     self.webView.backgroundColor = originalBackgroundColor;
     if (bambuserView != nil) {
         [bambuserView.view removeFromSuperview];
+        bambuserView = nil;
     }
     [self.commandDelegate sendPluginResult: [CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId: command.callbackId];
 }


### PR DESCRIPTION
IOS camera not release when calling hide view finder, so the camera is still active behind the webview